### PR TITLE
feat: add async parse index api

### DIFF
--- a/datasegment/parse_index.go
+++ b/datasegment/parse_index.go
@@ -53,7 +53,7 @@ func ParseDataSegmentIndexAsync(ctx context.Context, unpaddedReader io.Reader, r
 		default:
 			_, err := io.ReadFull(unpaddedReader, unpaddedBuf)
 			if err != nil {
-				if errors.Is(err, io.EOF) {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 					return nil
 				} else {
 					return xerrors.Errorf("reading 127 bytes from parsing: %w", err)


### PR DESCRIPTION
The motivation behind the new API is to allow validate index record as soon as they get produced, without having to wait of the parsing to finish. 

The old API left for compatibility, implementation has been changed to use the new async API under the hood. 